### PR TITLE
Ability to extend logic when mutating entities.

### DIFF
--- a/source/DefaultEcs/Entity.cs
+++ b/source/DefaultEcs/Entity.cs
@@ -64,16 +64,25 @@ namespace DefaultEcs
 
         #region Methods
 
-        internal void SetDisabled<T>(in T component) => World.GetEntityMutator().SetDisabled(this, component);
+        internal void SetDisabled<T>(in T component) { 
+            CheckEntity();
+            World.GetEntityMutator().SetDisabled(this, component);
+        }
 
-        internal void SetSameAsDisabled<T>(in Entity reference) => World.GetEntityMutator().SetSameAsDisabled<T>(this, reference);
+        internal void SetSameAsDisabled<T>(in Entity reference) { 
+            CheckEntity();
+            World.GetEntityMutator().SetSameAsDisabled<T>(this, reference);
+        }
 
         /// <summary>
         /// Gets whether the current <see cref="Entity"/> is enabled or not.
         /// </summary>
         /// <returns>true if the <see cref="Entity"/> is enabled; otherwise, false.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IsEnabled() => World.GetEntityAccessor().IsEnabled(this);
+        public bool IsEnabled() { 
+            CheckEntity();
+            return World.GetEntityAccessor().IsEnabled(this);
+        }
 
         /// <summary>
         /// Enables the current <see cref="Entity"/> so it can appear in <see cref="EntitySet"/>.
@@ -81,6 +90,7 @@ namespace DefaultEcs
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         public void Enable()
         {
+            CheckEntity();
             World.GetEntityMutator().Enable(this);
         }
 
@@ -90,6 +100,7 @@ namespace DefaultEcs
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         public void Disable()
         {
+            CheckEntity();
             World.GetEntityMutator().Disable(this);
         }
 
@@ -99,7 +110,10 @@ namespace DefaultEcs
         /// <typeparam name="T">The type of the component.</typeparam>
         /// <returns>true if the <see cref="Entity"/> has a component of type <typeparamref name="T"/> enabled; otherwise, false.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IsEnabled<T>() => World.GetEntityAccessor().IsEnabled<T>(this);
+        public bool IsEnabled<T>() { 
+            CheckEntity();
+            return World.GetEntityAccessor().IsEnabled<T>(this);
+        }
 
         /// <summary>
         /// Enables the current <see cref="Entity"/> component of type <typeparamref name="T"/> so it can appear in <see cref="EntitySet"/>.
@@ -107,7 +121,10 @@ namespace DefaultEcs
         /// </summary>
         /// <typeparam name="T">The type of the component.</typeparam>
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
-        public void Enable<T>() => World.GetEntityMutator().Enable<T>(this);
+        public void Enable<T>() { 
+            CheckEntity();
+            World.GetEntityMutator().Enable<T>(this);
+        }
 
         /// <summary>
         /// Disables the current <see cref="Entity"/> component of type <typeparamref name="T"/> so it does not appear in <see cref="EntitySet"/>.
@@ -115,7 +132,10 @@ namespace DefaultEcs
         /// </summary>
         /// <typeparam name="T">The type of the component.</typeparam>
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
-        public void Disable<T>() =>World.GetEntityMutator().Disable<T>(this);
+        public void Disable<T>() { 
+            CheckEntity();
+            World.GetEntityMutator().Disable<T>(this);
+        }
 
         /// <summary>
         /// Sets the value of the component of type <typeparamref name="T"/> on the current <see cref="Entity"/>.
@@ -124,7 +144,10 @@ namespace DefaultEcs
         /// <param name="component">The value of the component.</param>
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Max number of component of type <typeparamref name="T"/> reached.</exception>
-        public void Set<T>(in T component = default) => World.GetEntityMutator().Set(this, component);
+        public void Set<T>(in T component = default) { 
+            CheckEntity();
+            World.GetEntityMutator().Set(this, component);
+        }
 
         /// <summary>
         /// Sets the value of the component of type <typeparamref name="T"/> on the current <see cref="Entity"/> to the same instance of an other <see cref="Entity"/>.
@@ -134,13 +157,19 @@ namespace DefaultEcs
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Reference <see cref="Entity"/> comes from a different <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Reference <see cref="Entity"/> does not have a component of type <typeparamref name="T"/>.</exception>
-        public void SetSameAs<T>(in Entity reference) => World.GetEntityMutator().SetSameAs<T>(this, reference);
+        public void SetSameAs<T>(in Entity reference) {
+            CheckEntity();
+            World.GetEntityMutator().SetSameAs<T>(this, reference);
+        }
 
         /// <summary>
         /// Removes the component of type <typeparamref name="T"/> on the current <see cref="Entity"/>.
         /// </summary>
         /// <typeparam name="T">The type of the component.</typeparam>
-        public void Remove<T>() => World.GetEntityMutator().Remove<T>(this);
+        public void Remove<T>() {
+            CheckEntity();
+            World.GetEntityMutator().Remove<T>(this);
+        }
 
         /// <summary>
         /// Returns whether the current <see cref="Entity"/> has a component of type <typeparamref name="T"/>.
@@ -148,7 +177,10 @@ namespace DefaultEcs
         /// <typeparam name="T">The type of the component.</typeparam>
         /// <returns>true if the <see cref="Entity"/> has a component of type <typeparamref name="T"/>; otherwise, false.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Has<T>() => World.GetEntityAccessor().Has<T>(this);
+        public bool Has<T>() {
+            CheckEntity();
+            return World.GetEntityAccessor().Has<T>(this);
+        }
 
         /// <summary>
         /// Gets the component of type <typeparamref name="T"/> on the current <see cref="Entity"/>.
@@ -157,7 +189,10 @@ namespace DefaultEcs
         /// <returns>A reference to the component.</returns>
         /// <exception cref="Exception"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/> or does not have a component of type <typeparamref name="T"/>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref T Get<T>() => ref World.GetEntityAccessor().Get<T>(this);
+        public ref T Get<T>() {
+            CheckEntity();
+            return ref World.GetEntityAccessor().Get<T>(this);
+        }
 
         /// <summary>
         /// Makes it so when given <see cref="Entity"/> is disposed, current <see cref="Entity"/> will also be disposed.
@@ -165,7 +200,10 @@ namespace DefaultEcs
         /// <param name="parent">The <see cref="Entity"/> which acts as parent.</param>
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Child and parent <see cref="Entity"/> come from a different <see cref="DefaultEcs.World"/>.</exception>
-        public void SetAsChildOf(in Entity parent) => World.GetEntityMutator().SetAsChildOf(this, parent);
+        public void SetAsChildOf(in Entity parent) {
+            CheckEntity();
+            World.GetEntityMutator().SetAsChildOf(this, parent);
+        }
 
         /// <summary>
         /// Makes it so when current <see cref="Entity"/> is disposed, given <see cref="Entity"/> will also be disposed.
@@ -174,7 +212,10 @@ namespace DefaultEcs
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Child and parent <see cref="Entity"/> come from a different <see cref="DefaultEcs.World"/>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void SetAsParentOf(in Entity child) => World.GetEntityMutator().SetAsChildOf(this, child);
+        public void SetAsParentOf(in Entity child) {
+            CheckEntity();
+            World.GetEntityMutator().SetAsParentOf(this, child);
+        }
 
         /// <summary>
         /// Remove the given <see cref="Entity"/> from current <see cref="Entity"/> parents.
@@ -182,7 +223,10 @@ namespace DefaultEcs
         /// <param name="parent">The <see cref="Entity"/> which acts as parent.</param>
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Child and parent <see cref="Entity"/> come from a different <see cref="DefaultEcs.World"/>.</exception>
-        public void RemoveFromChildrenOf(in Entity parent) => World.GetEntityMutator().RemoveFromChildrenOf(this, parent);
+        public void RemoveFromChildrenOf(in Entity parent) {
+            CheckEntity();
+            World.GetEntityMutator().RemoveFromChildrenOf(this, parent);
+        }
 
         /// <summary>
         /// Remove the given <see cref="Entity"/> from current <see cref="Entity"/> children.
@@ -191,13 +235,19 @@ namespace DefaultEcs
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Child and parent <see cref="Entity"/> come from a different <see cref="DefaultEcs.World"/>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void RemoveFromParentsOf(in Entity child) => World.GetEntityMutator().RemoveFromParentsOf(this, child);
+        public void RemoveFromParentsOf(in Entity child) {
+            CheckEntity();
+            World.GetEntityMutator().RemoveFromParentsOf(this, child);
+        }
 
         /// <summary>
         /// Gets all the <see cref="Entity"/> setted as children of the current <see cref="Entity"/>.
         /// </summary>
         /// <returns>An <see cref="IEnumerable{Entity}"/> of all the current <see cref="Entity"/> children.</returns>
-        public IEnumerable<Entity> GetChildren() => World.GetEntityAccessor().GetChildren(this);
+        public IEnumerable<Entity> GetChildren() {
+            CheckEntity();
+            return World.GetEntityAccessor().GetChildren(this);
+        }
 
         /// <summary>
         /// Creates a copy of current <see cref="Entity"/> with all of its components in the given <see cref="DefaultEcs.World"/>.
@@ -205,15 +255,25 @@ namespace DefaultEcs
         /// <param name="world">The <see cref="DefaultEcs.World"/> instance to which copy current <see cref="Entity"/> and its components.</param>
         /// <returns>The created <see cref="Entity"/> in the given <see cref="DefaultEcs.World"/>.</returns>
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
-        public Entity CopyTo(World world) => World.GetEntityMutator().CopyTo(this, world);
+        public Entity CopyTo(World world) {
+            CheckEntity();
+            return World.GetEntityMutator().CopyTo(this, world);
+        }
 
         /// <summary>
         /// Calls on <paramref name="reader"/> with all the component of the current <see cref="Entity"/>.
         /// This method is primiraly used for serialization purpose and should not be called in game logic.
         /// </summary>
         /// <param name="reader">The <see cref="IComponentReader"/> instance to be used as callback with the current <see cref="Entity"/> components.</param>
-        public void ReadAllComponents(IComponentReader reader) => World.GetEntityAccessor().ReadAllComponents(this, reader);
+        public void ReadAllComponents(IComponentReader reader) {
+            CheckEntity();
+            World.GetEntityAccessor().ReadAllComponents(this, reader);                
+        } 
 
+        private void CheckEntity() {
+            if (WorldId == 0) throw new InvalidOperationException("Entity was not created from a World");
+        }
+        
         #endregion
 
         #region IDisposable

--- a/source/DefaultEcs/Entity.cs
+++ b/source/DefaultEcs/Entity.cs
@@ -6,7 +6,6 @@ using System.Runtime.InteropServices;
 using DefaultEcs.Serialization;
 using DefaultEcs.Technical;
 using DefaultEcs.Technical.Debug;
-using DefaultEcs.Technical.Message;
 
 namespace DefaultEcs
 {
@@ -20,14 +19,11 @@ namespace DefaultEcs
     {
         #region Fields
 
-        [FieldOffset(0)]
-        internal readonly short Version;
+        [FieldOffset(0)] internal readonly short Version;
 
-        [FieldOffset(2)]
-        internal readonly short WorldId;
+        [FieldOffset(2)] internal readonly short WorldId;
 
-        [FieldOffset(4)]
-        internal readonly int EntityId;
+        [FieldOffset(4)] internal readonly int EntityId;
 
         #endregion
 
@@ -64,12 +60,14 @@ namespace DefaultEcs
 
         #region Methods
 
-        internal void SetDisabled<T>(in T component) { 
+        internal void SetDisabled<T>(in T component)
+        {
             CheckEntity();
             World.GetEntityMutator().SetDisabled(this, component);
         }
 
-        internal void SetSameAsDisabled<T>(in Entity reference) { 
+        internal void SetSameAsDisabled<T>(in Entity reference)
+        {
             CheckEntity();
             World.GetEntityMutator().SetSameAsDisabled<T>(this, reference);
         }
@@ -79,7 +77,8 @@ namespace DefaultEcs
         /// </summary>
         /// <returns>true if the <see cref="Entity"/> is enabled; otherwise, false.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IsEnabled() { 
+        public bool IsEnabled()
+        {
             CheckEntity();
             return World.GetEntityAccessor().IsEnabled(this);
         }
@@ -110,7 +109,8 @@ namespace DefaultEcs
         /// <typeparam name="T">The type of the component.</typeparam>
         /// <returns>true if the <see cref="Entity"/> has a component of type <typeparamref name="T"/> enabled; otherwise, false.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IsEnabled<T>() { 
+        public bool IsEnabled<T>()
+        {
             CheckEntity();
             return World.GetEntityAccessor().IsEnabled<T>(this);
         }
@@ -121,7 +121,8 @@ namespace DefaultEcs
         /// </summary>
         /// <typeparam name="T">The type of the component.</typeparam>
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
-        public void Enable<T>() { 
+        public void Enable<T>()
+        {
             CheckEntity();
             World.GetEntityMutator().Enable<T>(this);
         }
@@ -132,7 +133,8 @@ namespace DefaultEcs
         /// </summary>
         /// <typeparam name="T">The type of the component.</typeparam>
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
-        public void Disable<T>() { 
+        public void Disable<T>()
+        {
             CheckEntity();
             World.GetEntityMutator().Disable<T>(this);
         }
@@ -144,7 +146,8 @@ namespace DefaultEcs
         /// <param name="component">The value of the component.</param>
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Max number of component of type <typeparamref name="T"/> reached.</exception>
-        public void Set<T>(in T component = default) { 
+        public void Set<T>(in T component = default)
+        {
             CheckEntity();
             World.GetEntityMutator().Set(this, component);
         }
@@ -157,7 +160,8 @@ namespace DefaultEcs
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Reference <see cref="Entity"/> comes from a different <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Reference <see cref="Entity"/> does not have a component of type <typeparamref name="T"/>.</exception>
-        public void SetSameAs<T>(in Entity reference) {
+        public void SetSameAs<T>(in Entity reference)
+        {
             CheckEntity();
             World.GetEntityMutator().SetSameAs<T>(this, reference);
         }
@@ -166,7 +170,8 @@ namespace DefaultEcs
         /// Removes the component of type <typeparamref name="T"/> on the current <see cref="Entity"/>.
         /// </summary>
         /// <typeparam name="T">The type of the component.</typeparam>
-        public void Remove<T>() {
+        public void Remove<T>()
+        {
             CheckEntity();
             World.GetEntityMutator().Remove<T>(this);
         }
@@ -177,7 +182,8 @@ namespace DefaultEcs
         /// <typeparam name="T">The type of the component.</typeparam>
         /// <returns>true if the <see cref="Entity"/> has a component of type <typeparamref name="T"/>; otherwise, false.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Has<T>() {
+        public bool Has<T>()
+        {
             CheckEntity();
             return World.GetEntityAccessor().Has<T>(this);
         }
@@ -189,7 +195,8 @@ namespace DefaultEcs
         /// <returns>A reference to the component.</returns>
         /// <exception cref="Exception"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/> or does not have a component of type <typeparamref name="T"/>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref T Get<T>() {
+        public ref T Get<T>()
+        {
             CheckEntity();
             return ref World.GetEntityAccessor().Get<T>(this);
         }
@@ -200,7 +207,8 @@ namespace DefaultEcs
         /// <param name="parent">The <see cref="Entity"/> which acts as parent.</param>
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Child and parent <see cref="Entity"/> come from a different <see cref="DefaultEcs.World"/>.</exception>
-        public void SetAsChildOf(in Entity parent) {
+        public void SetAsChildOf(in Entity parent)
+        {
             CheckEntity();
             World.GetEntityMutator().SetAsChildOf(this, parent);
         }
@@ -212,7 +220,8 @@ namespace DefaultEcs
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Child and parent <see cref="Entity"/> come from a different <see cref="DefaultEcs.World"/>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void SetAsParentOf(in Entity child) {
+        public void SetAsParentOf(in Entity child)
+        {
             CheckEntity();
             World.GetEntityMutator().SetAsParentOf(this, child);
         }
@@ -223,7 +232,8 @@ namespace DefaultEcs
         /// <param name="parent">The <see cref="Entity"/> which acts as parent.</param>
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Child and parent <see cref="Entity"/> come from a different <see cref="DefaultEcs.World"/>.</exception>
-        public void RemoveFromChildrenOf(in Entity parent) {
+        public void RemoveFromChildrenOf(in Entity parent)
+        {
             CheckEntity();
             World.GetEntityMutator().RemoveFromChildrenOf(this, parent);
         }
@@ -235,7 +245,8 @@ namespace DefaultEcs
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
         /// <exception cref="InvalidOperationException">Child and parent <see cref="Entity"/> come from a different <see cref="DefaultEcs.World"/>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void RemoveFromParentsOf(in Entity child) {
+        public void RemoveFromParentsOf(in Entity child)
+        {
             CheckEntity();
             World.GetEntityMutator().RemoveFromParentsOf(this, child);
         }
@@ -244,7 +255,8 @@ namespace DefaultEcs
         /// Gets all the <see cref="Entity"/> setted as children of the current <see cref="Entity"/>.
         /// </summary>
         /// <returns>An <see cref="IEnumerable{Entity}"/> of all the current <see cref="Entity"/> children.</returns>
-        public IEnumerable<Entity> GetChildren() {
+        public IEnumerable<Entity> GetChildren()
+        {
             CheckEntity();
             return World.GetEntityAccessor().GetChildren(this);
         }
@@ -255,7 +267,8 @@ namespace DefaultEcs
         /// <param name="world">The <see cref="DefaultEcs.World"/> instance to which copy current <see cref="Entity"/> and its components.</param>
         /// <returns>The created <see cref="Entity"/> in the given <see cref="DefaultEcs.World"/>.</returns>
         /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
-        public Entity CopyTo(World world) {
+        public Entity CopyTo(World world)
+        {
             CheckEntity();
             return World.GetEntityMutator().CopyTo(this, world);
         }
@@ -265,15 +278,17 @@ namespace DefaultEcs
         /// This method is primiraly used for serialization purpose and should not be called in game logic.
         /// </summary>
         /// <param name="reader">The <see cref="IComponentReader"/> instance to be used as callback with the current <see cref="Entity"/> components.</param>
-        public void ReadAllComponents(IComponentReader reader) {
+        public void ReadAllComponents(IComponentReader reader)
+        {
             CheckEntity();
-            World.GetEntityAccessor().ReadAllComponents(this, reader);                
-        } 
+            World.GetEntityAccessor().ReadAllComponents(this, reader);
+        }
 
-        private void CheckEntity() {
+        private void CheckEntity()
+        {
             if (WorldId == 0) throw new InvalidOperationException("Entity was not created from a World");
         }
-        
+
         #endregion
 
         #region IDisposable
@@ -296,8 +311,8 @@ namespace DefaultEcs
         /// <returns>true if the current object is equal to the other parameter; otherwise, false.</returns>
         public bool Equals(Entity other)
             => EntityId == other.EntityId
-            && WorldId == other.WorldId
-            && Version == other.Version;
+               && WorldId == other.WorldId
+               && Version == other.Version;
 
         #endregion
 

--- a/source/DefaultEcs/EntityAccessor.cs
+++ b/source/DefaultEcs/EntityAccessor.cs
@@ -5,9 +5,11 @@ using DefaultEcs.Serialization;
 using DefaultEcs.Technical;
 using DefaultEcs.Technical.Message;
 
-namespace DefaultEcs {
+namespace DefaultEcs
+{
     /// <inheritdoc />
-    public class EntityAccessor : IEntityAccessor {
+    public class EntityAccessor : IEntityAccessor
+    {
         /// <inheritdoc />
         public bool IsEnabled(Entity entity) =>
             entity.WorldId != 0 && GetComponentsReference(entity)[World.IsEnabledFlag];
@@ -24,21 +26,24 @@ namespace DefaultEcs {
         public ref T Get<T>(Entity entity) => ref ComponentManager<T>.Pools[entity.WorldId].Get(entity.EntityId);
 
         /// <inheritdoc />
-        public IEnumerable<Entity> GetChildren(Entity entity) {
+        public IEnumerable<Entity> GetChildren(Entity entity)
+        {
             foreach (int childId in entity.World?.EntityInfos[entity.EntityId].Children ?? Enumerable.Empty<int>()) {
                 yield return new Entity(entity.WorldId, childId);
             }
         }
 
         /// <inheritdoc />
-        public void ReadAllComponents(Entity entity, IComponentReader reader) {
+        public void ReadAllComponents(Entity entity, IComponentReader reader)
+        {
             Publisher.Publish(
                 entity.WorldId,
                 new ComponentReadMessage(entity.EntityId, reader ?? throw new ArgumentNullException(nameof(reader)))
             );
         }
 
-        private ref ComponentEnum GetComponentsReference(Entity entity) {
+        private ref ComponentEnum GetComponentsReference(Entity entity)
+        {
             return ref entity.World.EntityInfos[entity.EntityId].Components;
         }
     }

--- a/source/DefaultEcs/EntityAccessor.cs
+++ b/source/DefaultEcs/EntityAccessor.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DefaultEcs.Serialization;
+using DefaultEcs.Technical;
+using DefaultEcs.Technical.Message;
+
+namespace DefaultEcs {
+    /// <inheritdoc />
+    public class EntityAccessor : IEntityAccessor {
+        /// <inheritdoc />
+        public bool IsEnabled(Entity entity) =>
+            entity.WorldId != 0 && GetComponentsReference(entity)[World.IsEnabledFlag];
+
+        /// <inheritdoc />
+        public bool IsEnabled<T>(Entity entity) =>
+            entity.WorldId != 0 && GetComponentsReference(entity)[ComponentManager<T>.Flag];
+
+        /// <inheritdoc />
+        public bool Has<T>(Entity entity) => entity.WorldId < ComponentManager<T>.Pools.Length &&
+                                             (ComponentManager<T>.Pools[entity.WorldId]?.Has(entity.EntityId) ?? false);
+
+        /// <inheritdoc />
+        public ref T Get<T>(Entity entity) => ref ComponentManager<T>.Pools[entity.WorldId].Get(entity.EntityId);
+
+        /// <inheritdoc />
+        public IEnumerable<Entity> GetChildren(Entity entity) {
+            foreach (int childId in entity.World?.EntityInfos[entity.EntityId].Children ?? Enumerable.Empty<int>()) {
+                yield return new Entity(entity.WorldId, childId);
+            }
+        }
+
+        /// <inheritdoc />
+        public void ReadAllComponents(Entity entity, IComponentReader reader) {
+            Publisher.Publish(
+                entity.WorldId,
+                new ComponentReadMessage(entity.EntityId, reader ?? throw new ArgumentNullException(nameof(reader)))
+            );
+        }
+
+        private ref ComponentEnum GetComponentsReference(Entity entity) {
+            return ref entity.World.EntityInfos[entity.EntityId].Components;
+        }
+    }
+}

--- a/source/DefaultEcs/EntityAccessor.cs
+++ b/source/DefaultEcs/EntityAccessor.cs
@@ -11,22 +11,22 @@ namespace DefaultEcs
     public class EntityAccessor : IEntityAccessor
     {
         /// <inheritdoc />
-        public bool IsEnabled(Entity entity) =>
+        public virtual bool IsEnabled(Entity entity) =>
             entity.WorldId != 0 && GetComponentsReference(entity)[World.IsEnabledFlag];
 
         /// <inheritdoc />
-        public bool IsEnabled<T>(Entity entity) =>
+        public virtual bool IsEnabled<T>(Entity entity) =>
             entity.WorldId != 0 && GetComponentsReference(entity)[ComponentManager<T>.Flag];
 
         /// <inheritdoc />
-        public bool Has<T>(Entity entity) => entity.WorldId < ComponentManager<T>.Pools.Length &&
+        public virtual bool Has<T>(Entity entity) => entity.WorldId < ComponentManager<T>.Pools.Length &&
                                              (ComponentManager<T>.Pools[entity.WorldId]?.Has(entity.EntityId) ?? false);
 
         /// <inheritdoc />
-        public ref T Get<T>(Entity entity) => ref ComponentManager<T>.Pools[entity.WorldId].Get(entity.EntityId);
+        public virtual ref T Get<T>(Entity entity) => ref ComponentManager<T>.Pools[entity.WorldId].Get(entity.EntityId);
 
         /// <inheritdoc />
-        public IEnumerable<Entity> GetChildren(Entity entity)
+        public virtual IEnumerable<Entity> GetChildren(Entity entity)
         {
             foreach (int childId in entity.World?.EntityInfos[entity.EntityId].Children ?? Enumerable.Empty<int>()) {
                 yield return new Entity(entity.WorldId, childId);
@@ -34,7 +34,7 @@ namespace DefaultEcs
         }
 
         /// <inheritdoc />
-        public void ReadAllComponents(Entity entity, IComponentReader reader)
+        public virtual void ReadAllComponents(Entity entity, IComponentReader reader)
         {
             Publisher.Publish(
                 entity.WorldId,

--- a/source/DefaultEcs/EntityMutator.cs
+++ b/source/DefaultEcs/EntityMutator.cs
@@ -158,8 +158,9 @@ namespace DefaultEcs {
             {
                 Publisher.Publish(entity.WorldId, new EntityCopyMessage(entity.EntityId, copy));
 
+                copy.World.EntityInfos[copy.EntityId].Components = GetComponentsReference(entity);
                 ref ComponentEnum copyComponents = ref GetComponentsReference(copy);
-                copyComponents = GetComponentsReference(entity).Copy();
+                
                 if (entity.IsEnabled())
                 {
                     Publisher.Publish(entity.WorldId, new EntityEnabledMessage(copy.EntityId, copyComponents));

--- a/source/DefaultEcs/EntityMutator.cs
+++ b/source/DefaultEcs/EntityMutator.cs
@@ -22,7 +22,6 @@ namespace DefaultEcs {
 
         /// <inheritdoc />
         public void Enable(Entity entity) {
-            if (entity.WorldId == 0) Throw("Entity was not created from a World");
 
             ref ComponentEnum components = ref GetComponentsReference(entity);
             if (!components[World.IsEnabledFlag]) {
@@ -33,8 +32,6 @@ namespace DefaultEcs {
 
         /// <inheritdoc />
         public void Disable(Entity entity) {
-            if (entity.WorldId == 0) Throw("Entity was not created from a World");
-
             ref ComponentEnum components = ref GetComponentsReference(entity);
             if (components[World.IsEnabledFlag]) {
                 components[World.IsEnabledFlag] = false;
@@ -44,8 +41,6 @@ namespace DefaultEcs {
 
         /// <inheritdoc />
         public void Enable<T>(Entity entity) {
-            if (entity.WorldId == 0) Throw("Entity was not created from a World");
-
             if (entity.Has<T>()) {
                 ref ComponentEnum components = ref GetComponentsReference(entity);
                 if (!components[ComponentManager<T>.Flag]) {
@@ -57,8 +52,6 @@ namespace DefaultEcs {
 
         /// <inheritdoc />
         public void Disable<T>(Entity entity) {
-            if (entity.WorldId == 0) Throw("Entity was not created from a World");
-
             ref ComponentEnum components = ref GetComponentsReference(entity);
             if (components[ComponentManager<T>.Flag]) {
                 components[ComponentManager<T>.Flag] = false;
@@ -68,8 +61,6 @@ namespace DefaultEcs {
 
         /// <inheritdoc />
         public void Set<T>(Entity entity, in T component) {
-            if (entity.WorldId == 0) Throw("Entity was not created from a World");
-
             ref ComponentEnum components = ref GetComponentsReference(entity);
             if (ComponentManager<T>.GetOrCreate(entity.WorldId).Set(entity.EntityId, component)) {
                 components[ComponentManager<T>.Flag] = true;
@@ -81,8 +72,7 @@ namespace DefaultEcs {
 
         /// <inheritdoc />
         public void SetSameAs<T>(Entity target, in Entity reference) {
-            if (target.WorldId == 0) Throw("Entity was not created from a World");
-            if (target.WorldId != reference.World.WorldId) Throw("Reference Entity comes from a different World");
+            if (target.WorldId != reference.WorldId) Throw("Reference Entity comes from a different World");
             ComponentPool<T> pool = ComponentManager<T>.Get(target.WorldId);
             if (!(pool?.Has(reference.EntityId) ?? false))
                 Throw($"Reference Entity does not have a component of type {nameof(T)}");
@@ -109,7 +99,6 @@ namespace DefaultEcs {
         /// <inheritdoc />
         public void SetAsChildOf(Entity entity, in Entity parent) {
             if (entity.WorldId != parent.WorldId) Throw("Child and parent Entity come from a different World");
-            if (entity.WorldId == 0) Throw("Entity was not created from a World");
 
             ref HashSet<int> children = ref entity.World.EntityInfos[parent.EntityId].Children;
             children ??= new HashSet<int>();
@@ -126,7 +115,6 @@ namespace DefaultEcs {
         /// <inheritdoc />
         public void RemoveFromChildrenOf(Entity entity, in Entity parent) {
             if (entity.WorldId != parent.WorldId) Throw("Child and parent Entity come from a different World");
-            if (entity.WorldId == 0) Throw("Entity was not created from a World");
 
             HashSet<int> children = entity.World.EntityInfos[parent.EntityId].Children;
             if (children?.Remove(entity.EntityId) ?? false) {
@@ -151,8 +139,6 @@ namespace DefaultEcs {
         /// <inheritdoc />
         public Entity CopyTo(Entity entity, World world)
         {
-            if (entity.WorldId == 0) Throw("Entity was not created from a World");
-
             Entity copy = entity.IsEnabled() ? world.CreateEntity() : world.CreateDisabledEntity();
             try
             {
@@ -172,7 +158,7 @@ namespace DefaultEcs {
             }
             catch
             {
-                copy.Dispose();
+                Dispose(copy);
 
                 throw;
             }

--- a/source/DefaultEcs/EntityMutator.cs
+++ b/source/DefaultEcs/EntityMutator.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using DefaultEcs.Technical;
+using DefaultEcs.Technical.Message;
+
+namespace DefaultEcs {
+    /// <inheritdoc />
+    public class EntityMutator : IEntityMutator {
+        
+        /// <inheritdoc />
+        public void SetDisabled<T>(Entity entity, in T component) => ComponentManager<T>.GetOrCreate(entity.WorldId).Set(entity.EntityId, component);
+
+        /// <inheritdoc />
+        public void SetSameAsDisabled<T>(Entity entity, in Entity reference)
+        {
+            ComponentPool<T> pool = ComponentManager<T>.Get(entity.WorldId);
+            if (!(pool?.Has(reference.EntityId) ?? false)) Throw($"Reference Entity does not have a component of type {nameof(T)}");
+
+            pool?.SetSameAs(entity.EntityId, reference.EntityId);
+        }
+
+        /// <inheritdoc />
+        public void Enable(Entity entity) {
+            if (entity.WorldId == 0) Throw("Entity was not created from a World");
+
+            ref ComponentEnum components = ref GetComponentsReference(entity);
+            if (!components[World.IsEnabledFlag]) {
+                components[World.IsEnabledFlag] = true;
+                Publisher.Publish(entity.WorldId, new EntityEnabledMessage(entity.EntityId, components));
+            }
+        }
+
+        /// <inheritdoc />
+        public void Disable(Entity entity) {
+            if (entity.WorldId == 0) Throw("Entity was not created from a World");
+
+            ref ComponentEnum components = ref GetComponentsReference(entity);
+            if (components[World.IsEnabledFlag]) {
+                components[World.IsEnabledFlag] = false;
+                Publisher.Publish(entity.WorldId, new EntityDisabledMessage(entity.EntityId, components));
+            }
+        }
+
+        /// <inheritdoc />
+        public void Enable<T>(Entity entity) {
+            if (entity.WorldId == 0) Throw("Entity was not created from a World");
+
+            if (entity.Has<T>()) {
+                ref ComponentEnum components = ref GetComponentsReference(entity);
+                if (!components[ComponentManager<T>.Flag]) {
+                    components[ComponentManager<T>.Flag] = true;
+                    Publisher.Publish(entity.WorldId, new ComponentAddedMessage<T>(entity.EntityId, components));
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void Disable<T>(Entity entity) {
+            if (entity.WorldId == 0) Throw("Entity was not created from a World");
+
+            ref ComponentEnum components = ref GetComponentsReference(entity);
+            if (components[ComponentManager<T>.Flag]) {
+                components[ComponentManager<T>.Flag] = false;
+                Publisher.Publish(entity.WorldId, new ComponentRemovedMessage<T>(entity.EntityId, components));
+            }
+        }
+
+        /// <inheritdoc />
+        public void Set<T>(Entity entity, in T component) {
+            if (entity.WorldId == 0) Throw("Entity was not created from a World");
+
+            ref ComponentEnum components = ref GetComponentsReference(entity);
+            if (ComponentManager<T>.GetOrCreate(entity.WorldId).Set(entity.EntityId, component)) {
+                components[ComponentManager<T>.Flag] = true;
+                Publisher.Publish(entity.WorldId, new ComponentAddedMessage<T>(entity.EntityId, components));
+            } else if (components[ComponentManager<T>.Flag]) {
+                Publisher.Publish(entity.WorldId, new ComponentChangedMessage<T>(entity.EntityId, components));
+            }
+        }
+
+        /// <inheritdoc />
+        public void SetSameAs<T>(Entity target, in Entity reference) {
+            if (target.WorldId == 0) Throw("Entity was not created from a World");
+            if (target.WorldId != reference.World.WorldId) Throw("Reference Entity comes from a different World");
+            ComponentPool<T> pool = ComponentManager<T>.Get(target.WorldId);
+            if (!(pool?.Has(reference.EntityId) ?? false))
+                Throw($"Reference Entity does not have a component of type {nameof(T)}");
+
+            ref ComponentEnum components = ref GetComponentsReference(target);
+            if (pool.SetSameAs(target.EntityId, reference.EntityId)) {
+                components[ComponentManager<T>.Flag] = true;
+                Publisher.Publish(target.WorldId, new ComponentAddedMessage<T>(target.EntityId, components));
+            } else if (components[ComponentManager<T>.Flag]) {
+                Publisher.Publish(target.WorldId, new ComponentChangedMessage<T>(target.EntityId, components));
+            }
+        }
+
+        /// <inheritdoc />
+        public void Remove<T>(Entity entity) {
+            if (ComponentManager<T>.Get(entity.WorldId)?.Remove(entity.EntityId) ?? false) {
+                ref ComponentEnum components = ref GetComponentsReference(entity);
+                components[ComponentManager<T>.Flag] = false;
+                Publisher.Publish(entity.WorldId, new ComponentRemovedMessage<T>(entity.EntityId, components));
+            }
+        }
+
+
+        /// <inheritdoc />
+        public void SetAsChildOf(Entity entity, in Entity parent) {
+            if (entity.WorldId != parent.WorldId) Throw("Child and parent Entity come from a different World");
+            if (entity.WorldId == 0) Throw("Entity was not created from a World");
+
+            ref HashSet<int> children = ref entity.World.EntityInfos[parent.EntityId].Children;
+            children ??= new HashSet<int>();
+
+            if (children.Add(entity.EntityId)) {
+                entity.World.EntityInfos[entity.EntityId].Parents += children.Remove;
+            }
+        }
+
+        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetAsParentOf(Entity parent, in Entity child) => child.SetAsChildOf(parent);
+
+        /// <inheritdoc />
+        public void RemoveFromChildrenOf(Entity entity, in Entity parent) {
+            if (entity.WorldId != parent.WorldId) Throw("Child and parent Entity come from a different World");
+            if (entity.WorldId == 0) Throw("Entity was not created from a World");
+
+            HashSet<int> children = entity.World.EntityInfos[parent.EntityId].Children;
+            if (children?.Remove(entity.EntityId) ?? false) {
+                entity.World.EntityInfos[entity.EntityId].Parents -= children.Remove;
+            }
+        }
+
+        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void RemoveFromParentsOf(Entity parent, in Entity child) => child.RemoveFromChildrenOf(parent);
+
+        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose(Entity entity) {
+            Publisher.Publish(entity.WorldId, new EntityDisposingMessage(entity.EntityId));
+            Publisher.Publish(entity.WorldId, new EntityDisposedMessage(entity.EntityId));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void Throw(string message) => throw new InvalidOperationException(message);
+
+        /// <inheritdoc />
+        public Entity CopyTo(Entity entity, World world)
+        {
+            if (entity.WorldId == 0) Throw("Entity was not created from a World");
+
+            Entity copy = entity.IsEnabled() ? world.CreateEntity() : world.CreateDisabledEntity();
+            try
+            {
+                Publisher.Publish(entity.WorldId, new EntityCopyMessage(entity.EntityId, copy));
+
+                ref ComponentEnum copyComponents = ref GetComponentsReference(copy);
+                copyComponents = GetComponentsReference(entity).Copy();
+                if (entity.IsEnabled())
+                {
+                    Publisher.Publish(entity.WorldId, new EntityEnabledMessage(copy.EntityId, copyComponents));
+                }
+                else
+                {
+                    Publisher.Publish(entity.WorldId, new EntityDisabledMessage(copy.EntityId, copyComponents));
+                }
+            }
+            catch
+            {
+                copy.Dispose();
+
+                throw;
+            }
+
+            return copy;
+        }
+        
+        private ref ComponentEnum GetComponentsReference(Entity entity) {
+            return ref entity.World.EntityInfos[entity.EntityId].Components;
+        }
+    }
+}

--- a/source/DefaultEcs/IEntityAccessor.cs
+++ b/source/DefaultEcs/IEntityAccessor.cs
@@ -2,25 +2,26 @@ using System;
 using System.Collections.Generic;
 using DefaultEcs.Serialization;
 
-namespace DefaultEcs {
+namespace DefaultEcs
+{
     /// <summary>
     /// This interface needed to access Entity components and other stuff
     /// </summary>
-    public interface IEntityAccessor {
-        
+    public interface IEntityAccessor
+    {
         /// <summary>
         /// Gets whether the current <see cref="Entity"/> is enabled or not.
         /// </summary>
         /// <returns>true if the <see cref="Entity"/> is enabled; otherwise, false.</returns>
         bool IsEnabled(Entity entity);
-        
+
         /// <summary>
         /// Gets whether the current <see cref="Entity"/> component of type <typeparamref name="T"/> is enabled or not.
         /// </summary>
         /// <typeparam name="T">The type of the component.</typeparam>
         /// <returns>true if the <see cref="Entity"/> has a component of type <typeparamref name="T"/> enabled; otherwise, false.</returns>
         bool IsEnabled<T>(Entity entity);
-        
+
         /// <summary>
         /// Returns whether the current <see cref="Entity"/> has a component of type <typeparamref name="T"/>.
         /// </summary>
@@ -35,7 +36,7 @@ namespace DefaultEcs {
         /// <returns>A reference to the component.</returns>
         /// <exception cref="Exception"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/> or does not have a component of type <typeparamref name="T"/>.</exception>
         ref T Get<T>(Entity entity);
-        
+
         /// <summary>
         /// Gets all the <see cref="Entity"/> setted as children of the current <see cref="Entity"/>.
         /// </summary>

--- a/source/DefaultEcs/IEntityAccessor.cs
+++ b/source/DefaultEcs/IEntityAccessor.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using DefaultEcs.Serialization;
+
+namespace DefaultEcs {
+    /// <summary>
+    /// This interface needed to access Entity components and other stuff
+    /// </summary>
+    public interface IEntityAccessor {
+        
+        /// <summary>
+        /// Gets whether the current <see cref="Entity"/> is enabled or not.
+        /// </summary>
+        /// <returns>true if the <see cref="Entity"/> is enabled; otherwise, false.</returns>
+        bool IsEnabled(Entity entity);
+        
+        /// <summary>
+        /// Gets whether the current <see cref="Entity"/> component of type <typeparamref name="T"/> is enabled or not.
+        /// </summary>
+        /// <typeparam name="T">The type of the component.</typeparam>
+        /// <returns>true if the <see cref="Entity"/> has a component of type <typeparamref name="T"/> enabled; otherwise, false.</returns>
+        bool IsEnabled<T>(Entity entity);
+        
+        /// <summary>
+        /// Returns whether the current <see cref="Entity"/> has a component of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the component.</typeparam>
+        /// <returns>true if the <see cref="Entity"/> has a component of type <typeparamref name="T"/>; otherwise, false.</returns>
+        bool Has<T>(Entity entity);
+
+        /// <summary>
+        /// Gets the component of type <typeparamref name="T"/> on the current <see cref="Entity"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the component.</typeparam>
+        /// <returns>A reference to the component.</returns>
+        /// <exception cref="Exception"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/> or does not have a component of type <typeparamref name="T"/>.</exception>
+        ref T Get<T>(Entity entity);
+        
+        /// <summary>
+        /// Gets all the <see cref="Entity"/> setted as children of the current <see cref="Entity"/>.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable{Entity}"/> of all the current <see cref="Entity"/> children.</returns>
+        IEnumerable<Entity> GetChildren(Entity entity);
+
+        /// <summary>
+        /// Calls on <paramref name="reader"/> with all the component of the current <see cref="Entity"/>.
+        /// This method is primiraly used for serialization purpose and should not be called in game logic.
+        /// </summary>
+        /// <param name="entity">Entity to read from</param>
+        /// <param name="reader">The <see cref="IComponentReader"/> instance to be used as callback with the current <see cref="Entity"/> components.</param>
+        void ReadAllComponents(Entity entity, IComponentReader reader);
+    }
+}

--- a/source/DefaultEcs/IEntityMutator.cs
+++ b/source/DefaultEcs/IEntityMutator.cs
@@ -119,7 +119,7 @@ namespace DefaultEcs {
 
         /// <summary>
         /// Clean the current <see cref="Entity"/> of all its components.
-        /// The current <see cref="Entity"/> should not be used again after calling this method and <see cref="IsAlive"/> will return false.
+        /// The current <see cref="Entity"/> should not be used again after calling this method.
         /// </summary>
         /// <param name="entity">Entity to mutate</param>
         void Dispose(Entity entity);

--- a/source/DefaultEcs/IEntityMutator.cs
+++ b/source/DefaultEcs/IEntityMutator.cs
@@ -1,0 +1,136 @@
+using System;
+
+namespace DefaultEcs {
+    /// <summary>
+    /// A thing that responsible to mutate Entities
+    /// </summary>
+    public interface IEntityMutator {
+
+        /// <summary>
+        /// Some internal stuff 
+        /// </summary>
+        /// <param name="entity">Entity to mutate</param>
+        /// <param name="component"></param>
+        /// <typeparam name="T"></typeparam>
+        void SetDisabled<T>(Entity entity, in T component);
+
+        /// <summary>
+        /// Some internal stuff 
+        /// </summary>
+        /// <param name="entity">Entity to mutate</param>
+        /// <param name="reference"></param>
+        /// <typeparam name="T"></typeparam>
+        void SetSameAsDisabled<T>(Entity entity, in Entity reference);
+        
+        /// <summary>
+        /// Enables the current <see cref="Entity"/> so it can appear in <see cref="EntitySet"/>.
+        /// </summary>
+        /// <param name="entity">Entity to mutate</param>
+        /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
+        void Enable(Entity entity);
+
+        /// <summary>
+        /// Disables the current <see cref="Entity"/> so it does not appear in <see cref="EntitySet"/>.
+        /// </summary>
+        /// <param name="entity">Entity to mutate</param>
+        /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
+        void Disable(Entity entity);
+
+        /// <summary>
+        /// Enables the current <see cref="Entity"/> component of type <typeparamref name="T"/> so it can appear in <see cref="EntitySet"/>.
+        /// Does nothing if current <see cref="Entity"/> does not have a component of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="entity">Entity to mutate</param>
+        /// <typeparam name="T">The type of the component.</typeparam>
+        /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
+        void Enable<T>(Entity entity);
+
+        /// <summary>
+        /// Disables the current <see cref="Entity"/> component of type <typeparamref name="T"/> so it does not appear in <see cref="EntitySet"/>.
+        /// Does nothing if current <see cref="Entity"/> does not have a component of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="entity">Entity to mutate</param>
+        /// <typeparam name="T">The type of the component.</typeparam>
+        /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
+        void Disable<T>(Entity entity);
+
+        /// <summary>
+        /// Sets the value of the component of type <typeparamref name="T"/> on the current <see cref="Entity"/>.
+        /// </summary>
+        /// <param name="entity">Entity to mutate</param>
+        /// <typeparam name="T">The type of the component.</typeparam>
+        /// <param name="component">The value of the component.</param>
+        /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
+        /// <exception cref="InvalidOperationException">Max number of component of type <typeparamref name="T"/> reached.</exception>
+        void Set<T>(Entity entity, in T component);
+
+        /// <summary>
+        /// Sets the value of the component of type <typeparamref name="T"/> on the current <see cref="Entity"/> to the same instance of an other <see cref="Entity"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the component.</typeparam>
+        /// <param name="reference">The other <see cref="Entity"/> used as reference.</param>
+        /// <param name="target">Entity to mutate</param>
+        /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
+        /// <exception cref="InvalidOperationException">Reference <see cref="Entity"/> comes from a different <see cref="DefaultEcs.World"/>.</exception>
+        /// <exception cref="InvalidOperationException">Reference <see cref="Entity"/> does not have a component of type <typeparamref name="T"/>.</exception>
+        void SetSameAs<T>(Entity target, in Entity reference);
+
+        /// <summary>
+        /// Removes the component of type <typeparamref name="T"/> on the current <see cref="Entity"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the component.</typeparam>
+        void Remove<T>(Entity entity);
+
+        /// <summary>
+        /// Makes it so when given <see cref="Entity"/> is disposed, current <see cref="Entity"/> will also be disposed.
+        /// </summary>
+        /// <param name="entity">Entity to mutate</param>
+        /// <param name="parent">The <see cref="Entity"/> which acts as parent.</param>
+        /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
+        /// <exception cref="InvalidOperationException">Child and parent <see cref="Entity"/> come from a different <see cref="DefaultEcs.World"/>.</exception>
+        void SetAsChildOf(Entity entity, in Entity parent);
+
+        /// <summary>
+        /// Makes it so when current <see cref="Entity"/> is disposed, given <see cref="Entity"/> will also be disposed.
+        /// </summary>
+        /// <param name="parent">Entity to mutate</param>
+        /// <param name="child">The <see cref="Entity"/> which acts as child.</param>
+        /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
+        /// <exception cref="InvalidOperationException">Child and parent <see cref="Entity"/> come from a different <see cref="DefaultEcs.World"/>.</exception>
+        void SetAsParentOf(Entity parent, in Entity child);
+
+        /// <summary>
+        /// Remove the given <see cref="Entity"/> from current <see cref="Entity"/> parents.
+        /// </summary>
+        /// <param name="entity">Entity to mutate</param>
+        /// <param name="parent">The <see cref="Entity"/> which acts as parent.</param>
+        /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
+        /// <exception cref="InvalidOperationException">Child and parent <see cref="Entity"/> come from a different <see cref="DefaultEcs.World"/>.</exception>
+        void RemoveFromChildrenOf(Entity entity, in Entity parent);
+
+        /// <summary>
+        /// Remove the given <see cref="Entity"/> from current <see cref="Entity"/> children.
+        /// </summary>
+        /// <param name="parent">Entity to mutate</param>
+        /// <param name="child">The <see cref="Entity"/> which acts as child.</param>
+        /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
+        /// <exception cref="InvalidOperationException">Child and parent <see cref="Entity"/> come from a different <see cref="DefaultEcs.World"/>.</exception>
+        void RemoveFromParentsOf(Entity parent, in Entity child);
+
+        /// <summary>
+        /// Clean the current <see cref="Entity"/> of all its components.
+        /// The current <see cref="Entity"/> should not be used again after calling this method and <see cref="IsAlive"/> will return false.
+        /// </summary>
+        /// <param name="entity">Entity to mutate</param>
+        void Dispose(Entity entity);
+
+        /// <summary>
+        /// Creates a copy of current <see cref="Entity"/> with all of its components in the given <see cref="DefaultEcs.World"/>.
+        /// </summary>
+        /// <param name="entity">Entity to mutate</param>
+        /// <param name="world">The <see cref="DefaultEcs.World"/> instance to which copy current <see cref="Entity"/> and its components.</param>
+        /// <returns>The created <see cref="Entity"/> in the given <see cref="DefaultEcs.World"/>.</returns>
+        /// <exception cref="InvalidOperationException"><see cref="Entity"/> was not created from a <see cref="DefaultEcs.World"/>.</exception>
+        Entity CopyTo(Entity entity, World world);
+    }
+}

--- a/source/DefaultEcs/IEntityMutator.cs
+++ b/source/DefaultEcs/IEntityMutator.cs
@@ -1,11 +1,12 @@
 using System;
 
-namespace DefaultEcs {
+namespace DefaultEcs
+{
     /// <summary>
     /// A thing that responsible to mutate Entities
     /// </summary>
-    public interface IEntityMutator {
-
+    public interface IEntityMutator
+    {
         /// <summary>
         /// Some internal stuff 
         /// </summary>
@@ -21,7 +22,7 @@ namespace DefaultEcs {
         /// <param name="reference"></param>
         /// <typeparam name="T"></typeparam>
         void SetSameAsDisabled<T>(Entity entity, in Entity reference);
-        
+
         /// <summary>
         /// Enables the current <see cref="Entity"/> so it can appear in <see cref="EntitySet"/>.
         /// </summary>

--- a/source/DefaultEcs/World.cs
+++ b/source/DefaultEcs/World.cs
@@ -170,7 +170,8 @@ namespace DefaultEcs
         /// Sets world's EntityMutator
         /// </summary>
         /// <param name="entityMutator"></param>
-        public void SetEntityMutator(IEntityMutator entityMutator) {
+        public void SetEntityMutator(IEntityMutator entityMutator)
+        {
             _entityMutator = entityMutator;
         }
 
@@ -178,15 +179,17 @@ namespace DefaultEcs
         /// Returns current EntityMutator. 
         /// </summary>
         /// <returns></returns>
-        public IEntityMutator GetEntityMutator() {
+        public IEntityMutator GetEntityMutator()
+        {
             return _entityMutator;
         }
-        
+
         /// <summary>
         /// Sets world's EntityAccessor
         /// </summary>
         /// <param name="entityAccessor"></param>
-        public void SetEntityAccessor(IEntityAccessor entityAccessor) {
+        public void SetEntityAccessor(IEntityAccessor entityAccessor)
+        {
             _entityAccessor = entityAccessor;
         }
 
@@ -194,7 +197,8 @@ namespace DefaultEcs
         /// Returns current EntityAccessor. 
         /// </summary>
         /// <returns><see cref="IEntityAccessor"/></returns>
-        public IEntityAccessor GetEntityAccessor() {
+        public IEntityAccessor GetEntityAccessor()
+        {
             return _entityAccessor;
         }
 

--- a/source/DefaultEcs/World.cs
+++ b/source/DefaultEcs/World.cs
@@ -29,6 +29,9 @@ namespace DefaultEcs
         private readonly IntDispenser _entityIdDispenser;
 
         internal readonly short WorldId;
+        
+        private IEntityMutator _entityMutator;
+        private IEntityAccessor _entityAccessor;
 
         internal EntityInfo[] EntityInfos;
 
@@ -77,6 +80,8 @@ namespace DefaultEcs
             }
 
             _entityIdDispenser = new IntDispenser(-1);
+            _entityMutator = new EntityMutator();
+            _entityAccessor = new EntityAccessor();
             WorldId = (short)_worldIdDispenser.GetFreeInt();
 
             MaxEntityCount = maxEntityCount;
@@ -159,6 +164,38 @@ namespace DefaultEcs
             Publish(new EntityDisabledMessage(entityId, components));
 
             return new Entity(WorldId, entityId);
+        }
+
+        /// <summary>
+        /// Sets world's EntityMutator
+        /// </summary>
+        /// <param name="entityMutator"></param>
+        public void SetEntityMutator(IEntityMutator entityMutator) {
+            _entityMutator = entityMutator;
+        }
+
+        /// <summary>
+        /// Returns current EntityMutator. 
+        /// </summary>
+        /// <returns></returns>
+        public IEntityMutator GetEntityMutator() {
+            return _entityMutator;
+        }
+        
+        /// <summary>
+        /// Sets world's EntityAccessor
+        /// </summary>
+        /// <param name="entityAccessor"></param>
+        public void SetEntityAccessor(IEntityAccessor entityAccessor) {
+            _entityAccessor = entityAccessor;
+        }
+
+        /// <summary>
+        /// Returns current EntityAccessor. 
+        /// </summary>
+        /// <returns><see cref="IEntityAccessor"/></returns>
+        public IEntityAccessor GetEntityAccessor() {
+            return _entityAccessor;
         }
 
         /// <summary>


### PR DESCRIPTION
I moved all mutation logic to EntityMutator class, and all accessing logic to EntityAccessor class.
This is needed to be able to extend mutation logic by adding some additional checks and events. 
Also fixes #78 