### PR TITLE
mark entity as serializable

### DIFF
--- a/source/DefaultEcs/Entity.cs
+++ b/source/DefaultEcs/Entity.cs
@@ -17,6 +17,7 @@ namespace DefaultEcs
     /// </summary>
     [DebuggerTypeProxy(typeof(EntityDebugView))]
     [StructLayout(LayoutKind.Explicit)]
+    [Serializable]
     public readonly struct Entity : IDisposable, IEquatable<Entity>
     {
         #region Fields


### PR DESCRIPTION
In Unity structures and classes should be serializable in order to be shown in inspector