### PR TITLE
Get entity by entityid

### DIFF
--- a/source/DefaultEcs/Entity.cs
+++ b/source/DefaultEcs/Entity.cs
@@ -28,8 +28,11 @@ namespace DefaultEcs
         [FieldOffset(2)]
         internal readonly short WorldId;
 
+        /// <summary>
+        /// Entity ID
+        /// </summary>
         [FieldOffset(4)]
-        internal readonly int EntityId;
+        public readonly int EntityId;
 
         #endregion
 

--- a/source/DefaultEcs/World.cs
+++ b/source/DefaultEcs/World.cs
@@ -287,6 +287,16 @@ namespace DefaultEcs
         }
 
         /// <summary>
+        /// Get an existing entity
+        /// </summary>
+        /// <param name="entityId">entity Id</param>
+        /// <returns>Returns the entity</returns>
+        public Entity GetEntity(int entityId)
+        {
+            return new Entity(WorldId, entityId);
+        }
+
+        /// <summary>
         /// Sets up the current <see cref="World"/> to handle component of type <typeparamref name="T"/> with a different maximum count than <see cref="MaxCapacity"/>.
         /// If the type of component is already handled by the current <see cref="World"/>, does nothing.
         /// </summary>


### PR DESCRIPTION
It would be great to be able to access to an entity directly by using its entity id.

It will allow entity reference within components eg.

```
struct Damage
{
 public int Amount;
 public int OwnerEntityId;
}
```

and in a system whe can have stuff like :
```
[With(typeof(Damage))]
class SomeDamageSystem : AEntitySystem<float>
{
(...)
        protected override void Update(float state, ReadOnlySpan<Entity> entities)
        {
            foreach (ref readonly Entity entity in entities)
            {
                ref Damage damage = ref entity.Get<Damage>();
                Entity killerEntity = m_World.GetEntity(damage.OwnerEntityId);

                if (killerEntity.IsAlive)
                {
                    killerEntity.Set(new SomeReward(){(...)});
                }
            }
        }
}
```