### PR TITLE
Fix EntitySortedSet.Remove while fully used

### DIFF
--- a/source/DefaultEcs.Test/EntitySortedSetTest.cs
+++ b/source/DefaultEcs.Test/EntitySortedSetTest.cs
@@ -275,6 +275,19 @@ namespace DefaultEcs.Test
             Check.That(entity).IsEqualTo(removedEntity);
         }
 
+        [Fact]
+        public void Remove_While_Full_Should_Not_Crash()
+        {
+            using World world = new();
+
+            for (int i = 0; i < 8; i++) // choose count such that _entities is completly used
+                world.CreateEntity().Set(i);
+
+            using EntitySortedSet<int> set = world.GetEntities().AsSortedSet<int>();
+
+            set.GetEntities()[0].Remove<int>();
+        }
+
         #endregion
     }
 }

--- a/source/DefaultEcs/EntitySortedSet.cs
+++ b/source/DefaultEcs/EntitySortedSet.cs
@@ -176,7 +176,7 @@ namespace DefaultEcs
                 ref int index = ref _mapping[entityId];
                 if (index != -1)
                 {
-                    int length = Count-- - index;
+                    int length = --Count - index;
 
                     if (length > 0)
                     {


### PR DESCRIPTION
When an `EntitySortedSet` is fully used (all slots in `_entities`) the `Remove` method suffers from an off-by-one bug.

The test for it will be a bit finicky as it depends on the internal size of `_entities` which is set by the `EnsureLength` function.