### PR TITLE
Fixed README issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ DefaultEcs is an [Entity Component System](https://en.wikipedia.org/wiki/Entity_
 - [API documentation](./documentation/api/DefaultEcs.md 'API documentation')
 - [FAQ](./documentation/FAQ.md 'Frequently Asked Questions')
 - [Benchmarks](https://github.com/Doraku/Ecs.CSharp.Benchmark)
+<a/>
 
 - [Requirements](#requirements)
 - [Versioning](#versioning)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DefaultEcs is an [Entity Component System](https://en.wikipedia.org/wiki/Entity_
 [![preview package](https://img.shields.io/badge/preview-package-blue?style=flat&logo=github)](https://github.com/Doraku/DefaultEcs/packages/26448)
 [![Join the chat at https://gitter.im/Doraku/DefaultEcs](https://badges.gitter.im/Doraku/DefaultEcs.svg)](https://gitter.im/Doraku/DefaultEcs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-- [Api documentation](./documentation/api/DefaultEcs.md 'Api documentation')
+- [API documentation](./documentation/api/DefaultEcs.md 'API documentation')
 - [FAQ](./documentation/FAQ.md 'Frequently Asked Questions')
 - [Benchmarks](https://github.com/Doraku/Ecs.CSharp.Benchmark)
 
@@ -55,7 +55,7 @@ It is possible to use DefaultEcs in Unity (check [FAQ](./documentation/FAQ.md#un
 
 # Versioning
 This is the current strategy used to version DefaultEcs: v0.major.minor
-- 0: DefaultEcs is still in heavy development and although a lot of care is given not to break the current api, it can still happen
+- 0: DefaultEcs is still in heavy development and although a lot of care is given not to break the current API, it can still happen
 - major: incremented when there is a breaking change (reset minor number)
 - minor: incremented when there is a new feature or a bug fix
 
@@ -312,7 +312,7 @@ textureResourceManager.Manage(_world);
 This feature only cares for entity components, not the world components.
 
 ## Query
-To perform operations, systems should query entities from the world. This is performed by requesting entities through the world and using the fluent api to create rules
+To perform operations, systems should query entities from the world. This is performed by requesting entities through the world and using the fluent API to create rules
 ```csharp
 world
     .GetEntities() // this is the starting point of a query, you can also query disabled entities with GetDisabledEntities()

--- a/README.md
+++ b/README.md
@@ -10,79 +10,72 @@ DefaultEcs is an [Entity Component System](https://en.wikipedia.org/wiki/Entity_
 - [Api documentation](./documentation/api/DefaultEcs.md 'Api documentation')
 - [FAQ](./documentation/FAQ.md 'Frequently Asked Questions')
 - [Benchmarks](https://github.com/Doraku/Ecs.CSharp.Benchmark)
-<a/>
 
-- [Requirement](#Requirement)
-- [Versioning](#Versioning)
-- [Analyzer](#Analyzer)
-- [Overview](#Overview)
-  - [World](#Overview_World)
-    - [Message](#Overview_Message)
-  - [Entity](#Overview_Entity)
-  - [Component](#Overview_Component)
-    - [Singleton](#Overview_Singleton)
-    - [Resource](#Overview_Resource)
-  - [Query](#Overview_Query)
-    - [AsPredicate](#Overview_Query_AsPredicate)
-    - [AsEnumerable](#Overview_Query_AsEnumerable)
-    - [AsSet](#Overview_Query_AsSet)
-    - [AsMap](#Overview_Query_AsMap)
-    - [AsMultiMap](#Overview_Query_AsMultiMap)
-  - [System](#Overview_System)
-    - [ISystem](#Overview_System_ISystem)
-    - [ActionSystem](#Overview_System_ActionSystem)
-    - [SequentialSystem](#Overview_System_SequentialSystem)
-    - [ParallelSystem](#Overview_System_ParallelSystem)
-    - [AComponentSystem](#Overview_System_AComponentSystem)
-    - [AEntitySetSystem](#Overview_System_AEntitySetSystem)
-    - [AEntityMultiMapSystem](#Overview_System_AEntityMultiMapSystem)
-  - [Threading](#Overview_Threading)
-    - [IParallelRunnable](#Overview_Threading_IParallelRunnable)
-    - [IParallelRunner](#Overview_Threading_IParallelRunner)
-    - [DefaultParallelRunner](#Overview_Threading_DefaultParallelRunner)
-  - [Command](#Overview_Command)
-  - [Serialization](#Overview_Serialization)
-    - [TextSerializer](#Overview_Serialization_TextSerializer)
-    - [BinarySerializer](#Overview_Serialization_BinarySerializer)
-- [Extension](#Extension)
-- [Sample](#Sample)
-- [Projects using DefaultEcs](#Projects)
-- [Dependencies](#Dependencies)
+- [Requirements](#requirements)
+- [Versioning](#versioning)
+- [Analyzer](#analyzer)
+- [Overview](#overview)
+  - [World](#world)
+    - [Message](#message)
+  - [Entity](#entity)
+  - [Component](#component)
+    - [Singleton](#singleton)
+    - [Resource](#resource)
+  - [Query](#query)
+    - [AsPredicate](#aspredicate)
+    - [AsEnumerable](#asenumerable)
+    - [AsSet](#asset)
+    - [AsMap](#asmap)
+    - [AsMultiMap](#asmultimap)
+  - [System](#system)
+    - [ISystem](#isystem)
+    - [ActionSystem](#actionsystem)
+    - [SequentialSystem](#sequentialsystem)
+    - [ParallelSystem](#parallelsystem)
+    - [AComponentSystem](#acomponentsystem)
+    - [AEntitySetSystem](#aentitysetsystem)
+    - [AEntityMultiMapSystem](#aentitymultimapsystem)
+  - [Threading](#threading)
+    - [IParallelRunnable](#iparallelrunnable)
+    - [IParallelRunner](#iparallelrunner)
+    - [DefaultParallelRunner](#defaultparallelrunner)
+  - [Command](#command)
+  - [Serialization](#serialization)
+    - [TextSerializer](#textserializer)
+    - [BinarySerializer](#binaryserializer)
+- [Extension](#extension)
+- [Sample](#sample)
+- [Projects using DefaultEcs](#projects-using-defaultecs)
+- [Dependencies](#dependencies)
 
-<a name='Requirement'></a>
-# Requirement
+# Requirements
 DefaultEcs heavily uses features from C#7.0 and Span from the System.Memory package, compatible from .NETStandard 1.1.  
-For development, a C#9.0 compatible environment, net framework 4.8, net6.0 are required to build and run all tests (it is possible to disable some target in the test project if needed).  
+For development, a C#9.0 compatible environment, net framework 4.8, net6.0 are required to build and run all tests (it is possible to disable some targets in the test project if needed).  
 It is possible to use DefaultEcs in Unity (check [FAQ](./documentation/FAQ.md#unity)).
 
-<a name='Versioning'></a>
 # Versioning
 This is the current strategy used to version DefaultEcs: v0.major.minor
-- 0: DefaultEcs is still in heavy development and although a lot of care is given to not break the current api, it can still happen
+- 0: DefaultEcs is still in heavy development and although a lot of care is given not to break the current api, it can still happen
 - major: incremented when there is a breaking change (reset minor number)
 - minor: incremented when there is a new feature or a bug fix
 
-<a name='Analyzer'></a>
 # Analyzer
-To help development with DefaultEcs, there is a roslyn analyzer which provides code generator and warnings against potential bad usages. It can be found [here](https://github.com/Doraku/DefaultEcs.Analyzer).
+To help development with DefaultEcs, there is a roslyn analyzer which provides code generation and warnings against potential bad usage. It can be found [here](https://github.com/Doraku/DefaultEcs.Analyzer).
 
-<a name='Overview'></a>
 # Overview
-<a name='Overview_World'></a>
 ## World
-The World class act as the central hub to create entities, query specific entities,  get all components for a given type or publish and subscribe to messages that can be used to communicate across types.  
+The World class acts as the central hub to create entities, query specific entities, get all components for a given type or publish and subscribe to messages that can be used to communicate across types.  
 Multiple World objects can be used in parallel, each instance being thread-safe from one another but operations performed on a single instance and all of its created items should be thought as non thread-safe. Depending on what is done, it is still possible to process operations concurrently to optimise performance.
 
-Worlds are created as such
+Worlds are created as such:
 ```csharp
 World world = new World();
 ```
 
-The World class also implement the `IDisposable` interface so you can easily cleanup an instance resources by disposing it.
+The World class also implements the `IDisposable` interface so you can easily clean up resources by disposing it.
 
-<a name='Overview_Message'></a>
 ### Message
-It is possible to send and receive message transiting in a World.
+It is possible to send and receive message transiting in a World:
 ```csharp
 void On(in bool message) { }
 
@@ -93,7 +86,7 @@ world.Subscribe<bool>(On);
 world.Publish(true);
 ```
 
-It is also possible to subscribe to multiple method of an instance by using the SubscribeAttribute:
+It is also possible to subscribe to multiple methods of an instance by using the `SubscribeAttribute`:
 ```csharp
 public class Dummy
 {
@@ -118,18 +111,17 @@ world.Publish(true);
 world.Publish(string.Empty);
 ```
 
-Note that the Subscribe method return an IDisposable object acting as a subscription. To unsubscribe, simply dispose this object.
+Note that the Subscribe method returns an `IDisposable` object acting as a subscription. To unsubscribe, simply dispose this object.
 
-<a name='Overview_Entity'></a>
 ## Entity
-Entities are simple struct acting as a key to manage components.
+Entities are simple structs acting as keys to manage components.
 
-Entities are created as such
+Entities are created as such:
 ```csharp
 Entity entity = world.CreateEntity();
 ```
 
-You should not store entities yourself and rely as much as possible on returned object from a world query as those will be updated accordingly to component changes.  
+You should not store entities yourself and rely as much as possible on the returned objects from a world query as those will be updated accordingly to component changes.  
 To clear an entity, simply call its `Dispose` method.
 ```csharp
 entity.Dispose();
@@ -145,7 +137,7 @@ if (!entity.IsAlive)
 #endif
 ```
 
-You can also make an entity act as if it was disposed so it is removed from world queries while keeping all its components, this is useful when you need to activate/diactivate entity from your game logic
+You can also make an entity act as if it was disposed so it is removed from world queries while keeping all its components, this is useful when you need to activate/deactivate an entity from your game logic:
 ```csharp
 entity.Disable();
 
@@ -158,9 +150,8 @@ entity.Enable();
 entity.IsEnabled();
 ```
 
-<a name='Overview_Component'></a>
 ## Component
-Components are not restricted by any heritage hierarchy. It is recommanded that component objects only hold data and to be struct to generate as little as possible garbage and to have them contiguous in memory but you can use class type and interface too.
+Components are not restricted by any heritage hierarchy. It is recommended that component objects only hold data and be structs to generate as little as possible garbage and to have them contiguous in memory, but you can use classes and interfaces too:
 ```csharp
 public struct Example
 {
@@ -178,12 +169,12 @@ public class CExample : IExample
 }
 ```
 
-To reduce memory usage, it is possible to set a maximum capacity for a given component type. If nothing is set, then the maximum entity count of the world will be used. This call need to be done before any component of the specified type is set.
+To reduce memory usage, it is possible to set a maximum capacity for a given component type. If nothing is set, then the maximum entity count of the world will be used. This call needs to be done before any component of the specified type is set:
 ```csharp
 world.SetMaxCapacity<Example>(42);
 ```
 
-Components can live on two level, on entities or directly on the world itself.
+Components can live on two levels, on entities or directly on the world itself:
 ```csharp
 entity.Set<int>(42);
 
@@ -206,14 +197,14 @@ if (world.Has<int>() && --world.Get<int>() <= 0)
     world.Remove<int>();
 }
 
-// be carefull that the component type is specific to the method generic parameter type, not the component type
+// be careful that the component type is specific to the method generic parameter type, not the component type
 entity.Set<IExample>(new CExample());
 
 // this will return false as the component type previously set is IExample, not CExample
 entity.Has<CExample>();
 ```
 
-It is possible to share the same component value between entities or even the world value. This is useful if you want to update a component value on multiple entities with a single call.
+It is possible to share the same component value between entities or even the world. This is useful if you want to update a component value on multiple entities with a single call:
 ```csharp
 referenceEntity.Set<int>(42);
 entity.SetSameAs<int>(referenceEntity);
@@ -228,9 +219,10 @@ world.Set<string>("world");
 // the value for entity will also be "world"
 entity.Get<string>();
 ```
+
 If the component is removed from the entity used as reference or the world, it will not remove the component from the other entities using the same component.
 
-Component on entities can also be disabled and reenabled. This is useful if you want to quickly make an entity act as if its component composition has changed so it is picked up by world queries without paying the price to actually remove a component.
+Components on entities can also be disabled and re-enabled. This is useful if you want to quickly make an entity act as if its component composition has changed so it is picked up by world queries without paying the price of actually removing the component:
 ```csharp
 entity.Disable<int>();
 
@@ -244,7 +236,7 @@ entity.Enable<int>();
 entity.IsEnabled<int>();
 ```
 
-There is two way to update a component value, either use the `Set<T>(newValue)` method or setting/editing the value returned by `Get<T>()`. One major difference between the two is that `Set<T>(newValue)` will also notify internal queries that the component value has changed.
+There are two ways to update a component value, either use the `Set<T>(newValue)` method or set/edit the value returned by `Get<T>()`. One major difference between the two is that `Set<T>(newValue)` will also notify internal queries that the component value has changed:
 ```csharp
 entity.Set<int>(42);
 
@@ -259,10 +251,9 @@ component = 42;
 entity.NotifyChanged<int>();
 ```
 
-<a name='Overview_Singleton'></a>
 ### Singleton
 By combining the previous calls, it is possible to define a component type as a singleton:
-```
+```csharp
 // only one component value for int can exist on this world
 world.SetMaxCapacity<int>(1);
 
@@ -274,13 +265,12 @@ world.Set<int>(42);
 entity.SetSameAsWorld<int>();
 ```
 
-<a name='Overview_Resource'></a>
 ### Resource
-Not all components can easily be serialized to be loaded from data file (texture, sound, ...). To help with the handling of those cases, helper types are provided to give a way to load managed resources, shared across entities and even worlds, and automatically dispose them once no entity using them exist anymore.  
-To setup a managed resource on an entity, the type `ManagedResource<TInfo, TResource>` need to be set as a component where TInfo is a type used as a single identifier for a single resource and information needed to load it, and TResource is the type of the resource.  
-Should multiple resource of the same type be needed on a single entity, it is also possible to set the type `ManagedResource<TInfo[], TResource>` as component.  
-If the `ManagedResource` component is removed from the entity or the entity holding it disposed, the internal reference count on the resource will decrease and it will be disposed if zero is reached.  
-To actually load the resource, an implementation of the class `AResourceManager<TInfo, TResource>` is need as shown in the next exemple:
+Not all components can easily be serialized to be loaded from data files (texture, sound, ...). To help with the handling of those cases, helper types are provided to provide a way to load managed resources, shared across entities and even worlds, and automatically dispose them once no entity using them exists anymore.  
+To set up a managed resource on an entity, the type `ManagedResource<TInfo, TResource>` needs to be set as a component where `TInfo` is a type used as a single identifier for a single resource and information needed to load it, and `TResource` is the type of the resource.  
+Should multiple resources of the same type be needed on a single entity, it is also possible to set the type `ManagedResource<TInfo[], TResource>` as a component.  
+If the `ManagedResource` component is removed from the entity or the entity holding it is disposed, the internal reference count on the resource will decrease and it will be disposed if zero is reached.  
+To actually load the resource, an implementation of the class `AResourceManager<TInfo, TResource>` is needed as shown in the example:
 ```csharp
 // TInfo is string, the name of the texture and TResource is Texture2D
 public sealed class TextureResourceManager : AResourceManager<string, Texture2D>
@@ -316,30 +306,28 @@ entity.Set(new ManagedResource<string[], Texture2D>(new [] { "square.png", "circ
 entity.Set(ManagedResource<Texture2D>.Create("square.png")); // set up a ManagedResource<string, Texture2D>
 entity.Set(ManagedResource<Texture2D>.Create("square.png", "circle.png")); // set up a ManagedResource<string[], Texture2D>
 
-// this is how to set up a resource manager on a world, it will process all curently existing entities with the special component type, and react to all futur entities also
+// this is how to set up a resource manager on a world, it will process all currently existing entities with the special component type, and react to all future entities also
 textureResourceManager.Manage(_world);
 ```
-This feature only care for entities component, not the world component.
+This feature only cares for entity components, not the world components.
 
-<a name='Overview_Query'></a>
 ## Query
-To perform operation, systems should query entities from the world. This is performed by requesting entities through the world and using the fluent api to create rules
+To perform operations, systems should query entities from the world. This is performed by requesting entities through the world and using the fluent api to create rules
 ```csharp
 world
     .GetEntities() // this is the starting point of a query, you can also query disabled entities with GetDisabledEntities()
     .With<int>().With<double>() // require that entities have both an int and double components
     .Without<string>().Without<char>() // require that entities do not have both a string nor a char component
     .WithEither<long>().Or<ulong>() // require that entities have either a long or ulong component
-    .WithoutEither<short>().Or<ushort>() // require that entities doe no have either a short or a ushort component
+    .WithoutEither<short>().Or<ushort>() // require that entities do not have either a short or a ushort component
     ...
     .WhenAdded<int>() // require that entities have just been added an int component
     .WhenChanged<int>() // require that entities have their int component changed
     .WhenRemoved<string>() // require that entities have their string component removed
     ...
 ```
-Once you are satified with the rules you can then finish the query by chosing how to get the entities.
 
-<a name='Overview_Query_AsPredicate'></a>
+Once you are satisfied with the rules you can then finish the query by choosing how to get the entities:
 ### AsPredicate
 ```csharp
 world
@@ -347,10 +335,9 @@ world
     ...
     .AsPredicate();
 ```
-Get a `Predicate<Entity>` that check for your declared rules. `When...` rules are ignored.  
+Gets a `Predicate<Entity>` that checks for your declared rules. `When...` rules are ignored.  
 This is useful if you need to check for some entity component composition.
 
-<a name='Overview_Query_AsEnumerable'></a>
 ### AsEnumerable
 ```csharp
 world
@@ -358,10 +345,9 @@ world
     ...
     .AsEnumerable();
 ```
-Get a `IEnumerable<Entity>` that when enumerated returns all the entities respecting your declared rules. `When...` rules are ignored.  
+Gets an `IEnumerable<Entity>` that when enumerated returns all the entities respecting your declared rules. `When...` rules are ignored.  
 This is useful if you need to do an initialisation on specific entities, this should not be used in a hot path.
 
-<a name='Overview_Query_AsSet'></a>
 ### AsSet
 ```csharp
 world
@@ -369,11 +355,10 @@ world
     ...
     .AsSet();
 ```
-Get a `EntitySet` containing all entities respecting your declared rules. Its content is cached for fast access and is automatically updated as you change your entities composition.
+Gets an `EntitySet` containing all entities respecting your declared rules. Its content is cached for fast access and is automatically updated as you change your entity component composition.
 If `When...` rules are present, you should call its `Complete()` method once you are done processing its entities to clear it.
 This is the base type used in the provided system implementation.
 
-<a name='Overview_Query_AsMap'></a>
 ### AsMap
 ```csharp
 world
@@ -381,11 +366,10 @@ world
     ...
     .AsMap<TKey>();
 ```
-Get a `EntityMap<TKey>` which map a single entity with a component type `TKey` value. Its content is cached for fast access and is automatically updated as you change your entities composition.
+Gets an `EntityMap<TKey>` which maps a single entity with a component type of `TKey` value. Its content is cached for fast access and is automatically updated as you change your entity component composition.
 If `When...` rules are present, you should call its `Complete()` method once you are done processing its entities to clear it.
-This is useful if you need o(1) access to an entity based on a key.
+This is useful if you need O(1) access to an entity based on a key.
 
-<a name='Overview_Query_AsMultiMap'></a>
 ### AsMultiMap
 ```csharp
 world
@@ -393,22 +377,19 @@ world
     ...
     .AsMultiMap<TKey>();
 ```
-Get a `EntityMultiMap<TKey>` which map multiple entities with a component type `TKey` value. Its content is cached for fast access and is automatically updated as you change your entities composition.
+Gets an `EntityMultiMap<TKey>` which maps multiple entities with a component type of `TKey` value. Its content is cached for fast access and is automatically updated as you change your entity component composition.
 If `When...` rules are present, you should call its `Complete()` method once you are done processing its entities to clear it.
-This is useful if you need o(1) access to entities based on a key.
+This is useful if you need O(1) access to entities based on a key.
 
-<a name='Overview_System'></a>
 ## System
-Although there is no obligation, a set of base classes are provided to help the creation of systems:
-<a name='Overview_System_ISystem'></a>
+Although there is no obligation to use them, a set of base classes is provided to help with the creation of systems:
 ### ISystem
-This is a base interface for all the systems. it exposes an `Update` method and an `IsEnabled` property. In all derived types provided in DefaultEcs, the responsibility to check this property is handled by the callee, not the caller. It is set to true by default.
+This is a base interface for all systems. It exposes an `Update` method and an `IsEnabled` property. In all derived types provided in DefaultEcs, the responsibility to check this property is handled by the callee, not the caller. It is set to true by default.
 
-<a name='Overview_System_ActionSystem'></a>
 ### ActionSystem
-This class is used to quickly make a system with a given custom action to be called on every update.
+This class is used to quickly make a system with a given custom action to be called on every update:
 ```csharp
-private void Exit(float elaspedTime)
+private void Exit(float elapsedTime)
 {
     if (EscapedIsPressed)
     {
@@ -426,9 +407,8 @@ ISystem<float> system = new ActionSystem<float>(Exit);
 system.Update(elapsedTime);
 ```
 
-<a name='Overview_System_SequentialSystem'></a>
 ### SequentialSystem
-This class is used to easily create a list of system to be updated in a sequential order.
+This class is used to easily create a list of systems to be updated in a sequential order:
 ```csharp
 ISystem<float> system = new SequentialSystem<float>(
     new InputSystem(),
@@ -438,12 +418,11 @@ ISystem<float> system = new SequentialSystem<float>(
 );
 ...
 
-// this will call in order InputSystem, AISystem, PositionSystem and DrawSystem
-syste
+// this will call the systems in order: InputSystem -> AISystem -> PositionSystem -> DrawSystem
+```
 
-<a name='Overview_System_ParallelSystem'></a>
 ### ParallelSystem
-This class is used to easily create a list of system to be updated in parallel.
+This class is used to easily create a list of systems to be updated in parallel:
 ```csharp
 ISystem<float> system = new ParallelSystem<float>(
     new DefaultParallelRunner(Environment.ProcessorCount),    
@@ -454,12 +433,11 @@ ISystem<float> system = new ParallelSystem<float>(
 );
 ...
 
-// this will call all systems in parallel
+// this will call the systems in parallel
 ```
 
-<a name='Overview_System_AComponentSystem'></a>
 ### AComponentSystem
-This is a base class to create system to update a specific component type from a given World.
+This is a base class to create systems that update based on a specific component type from a given World:
 ```csharp
 public class DrawSystem : AComponentSystem<float, DrawInfo>
 {
@@ -473,27 +451,26 @@ public class DrawSystem : AComponentSystem<float, DrawInfo>
         _square = square;
     }
 
-    protected override void PreUpdate(float elaspedTime)
+    protected override void PreUpdate(float elapsedTime)
     {
         _batch.Begin();
     }
 
-    protected override void Update(float elaspedTime, ref DrawInfo component)
+    protected override void Update(float elapsedTime, ref DrawInfo component)
     {
         _batch.Draw(_square, component.Destination, component.Color);
     }
 
-    protected override void PostUpdate(float elaspedTime)
+    protected override void PostUpdate(float elapsedTime)
     {
         _batch.End();
     }
 }
 ```
-Note that components do not have to reside on an entities to be processed by such a system (world components) and their enable/disable state on their owning entity is ignored.
+Note that components do not have to reside on entities to be processed by such a system (world components) and their enabled/disabled state on their owning entity is ignored.
 
-<a name='Overview_System_AEntitySetSystem'></a>
 ### AEntitySetSystem
-This is a base class to create system to update a given EntitySet.
+This is a base class to create system to update a given `EntitySet`:
 ```csharp
 public sealed class VelocitySystem : AEntitySetSystem<float>
 {
@@ -502,12 +479,12 @@ public sealed class VelocitySystem : AEntitySetSystem<float>
     {
     }
 
-    protected override void Update(float elaspedTime, in Entity entity)
+    protected override void Update(float elapsedTime, in Entity entity)
     {
         ref Velocity velocity = ref entity.Get<Velocity>();
         ref Position position = ref entity.Get<Position>();
 
-        Vector2 offset = velocity.Value * elaspedTime;
+        Vector2 offset = velocity.Value * elapsedTime;
 
         position.Value.X += offset.X;
         position.Value.Y += offset.Y;
@@ -515,7 +492,7 @@ public sealed class VelocitySystem : AEntitySetSystem<float>
 }
 ```
 
-It is also possible to declare the needed component by using the WithAttribute and WithoutAttribute on the system type.
+It is also possible to declare the component types by using the `WithAttribute` and `WithoutAttribute` on the system type:
 ```csharp
 [With(typeof(Velocity)]
 [With(typeof(Position)]
@@ -526,27 +503,25 @@ public sealed class VelocitySystem : AEntitySetSystem<float>
     {
     }
 
-    protected override void Update(float elaspedTime, in Entity entity)
+    protected override void Update(float elapsedTime, in Entity entity)
     {
         ref Velocity velocity = ref entity.Get<Velocity>();
         ref Position position = ref entity.Get<Position>();
 
-        Vector2 offset = velocity.Value * elaspedTime;
+        Vector2 offset = velocity.Value * elapsedTime;
 
         position.Value.X += offset.X;
         position.Value.Y += offset.Y;
     }
 }
 ```
-    - [AEntityMultiMapSystem](#Overview_System_AEntityMultiMapSystem)
 
-<a name='Overview_System_AEntityMultiMapSystem'></a>
 ### AEntityMultiMapSystem
-This is a base class to create system to update a given EntityMultiMap. If the key implemente `IComparable`, they keys will processed in a sorted order, or you can give your own key order.
+This is a base class to create systems that update a given `EntityMultiMap`. If the key implements `IComparable`, the keys will be processed in a sorted order. Otherwise you can provide your own key order:
 ```csharp
 public sealed class LayerSystem : AEntityMultiMapSystem<float, Layer>
 {
-    // we define the layers order
+    // we define the layer order
     private static readonly Layer[] _layers = new[]
     {
         Layer.Background,
@@ -555,7 +530,6 @@ public sealed class LayerSystem : AEntityMultiMapSystem<float, Layer>
         Layer.Ui
     };
 
-    [ConstructorParameter]
     private readonly SpriteBatch _batch;
     
     public LayerSystem(SpriteBatch batch, World world)
@@ -564,47 +538,48 @@ public sealed class LayerSystem : AEntityMultiMapSystem<float, Layer>
         _batch = batch;
     }
 
-    protected override Span<Layer> GetKeys() => _layers.AsSpan();
+    protected override Span<Layer> GetKeys()
+    {
+        return _layers.AsSpan();
+    }
 
     // entities will be drawn layer by layer
-    protected override void Update(float state, in Layer key, in Entity entity) => _batch.Draw(drawInfo.Texture, drawInfo.Position, null, drawInfo.Color, drawInfo.Rotation, drawInfo.Origin, drawInfo.Size, SpriteEffects.None, 0f);
+    protected override void Update(float state, in Layer key, in Entity entity)
+    {
+        _batch.Draw(drawInfo.Texture, drawInfo.Position, null, drawInfo.Color, drawInfo.Rotation, drawInfo.Origin, drawInfo.Size, SpriteEffects.None, 0f);
+    }
 }
 ```
 
-<a name='Overview_Threading'></a>
 ## Threading
-Some systems are compatible with multithreading execution: ParallelSystem, AEntitySetSystem and AComponentSystem. This is done by passing a IParallelRunner to their respective constructor.
+Some systems are compatible with multi-threaded execution: `ParallelSystem`, `AEntitySetSystem` and `AComponentSystem`. This is done by passing an `IParallelRunner` to their respective constructors:
 ```csharp
 IParallelRunner runner = new DefaultParallelRunner(Environment.ProcessorCount);
 
 ISystem<float> system = new VelocitySystem(world, runner);
 
 // this will process the update on Environment.ProcessorCount threads
-system.Update(elaspedTime);
+system.Update(elapsedTime);
 ```
-It is safe to run a system with multithreading when:
+It is safe to run a system with multi-threading when:
 * for an AEntitySetSystem or an AEntityMultiMapSystem
-  * each entity can be safely updated separately with no dependency to an other entity
-  * there is no composition altering operation done on a world nor on an entity. Here is a list of non thread safe operations you shouldn't do, see [Command](#Overview_Command) for how to perform such operations safely:
-    * Create an Entity
-    * SetMaxCapacity on a World
-    * Optimize a World
-    * TrimExcess a World
-    * Dispose an Entity
-    * Set/SameAs/SameAsWorld a component on an Entity or a World
-    * Remove a component on an Entity or a World
-    * Enable an Entity
-    * Disable an Entity
-    * Enable a component on an Entity
-    * Disable a component on an Entity
-    * NotifyChanged a component on an Entity
-    * CopyTo an Entity
-* for an AComponentSystem
-  * each component can be safely updated separately with no dependency to an other component
+  * each entity with no dependency to another entity can be safely updated separately
+  * there is no entity component composition altering operation done on a world nor on an entity. Here is a list of non thread-safe operations you shouldn't do, see [Command](#Overview_Command) for how to perform such operations safely:
+    * Creating and disposing an entity
+    * Removing a component from an entity/world
+    * Enabling or disabling an entity
+    * Enabling or disabling a component on an entity
+    * Calling `SetMaxCapacity` on a world
+    * Calling `Optimize` on a world
+    * Calling `TrimExcess` on a world
+    * Calling `Set`/`SameAs`/`SameAsWorld` on an entity/world
+    * Calling `NotifyChanged` on an entity
+    * Calling `CopyTo` on an entity
+* for an `AComponentSystem`
+  * each component with no dependency to another component can be safely updated separately
 
-<a name='Overview_Threading_IParallelRunnable'></a>
 ### IParallelRunnable
-This interface allow the creation of custom parallelisable process by an IParallelRunner.
+This interface allows for creation of a custom parallelisable process by an `IParallelRunner`:
 ```csharp
 IParallelRunner runner = new DefaultParallelRunner(Environment.ProcessorCount);
 
@@ -612,29 +587,30 @@ public class CustomRunnable : IParallelRunnable
 {
     public void Run(int index, int maxIndex)
     {
-        // a runnable is separated in (maxIndex + 1) part to run in parallel, index gives you the part running
+        // a runnable is separated into (maxIndex + 1) parts running in parallel, index indicates the part currently running
     }
 }
 
 runner.Run(new CustomRunnable());
 ```
 
-<a name='Overview_Threading_IParallelRunner'></a>
 ### IParallelRunner
-This interface allow the creation of custom parallel execution.
+This interface allows for creation of custom parallel execution:
 ```csharp
 public class TaskRunner : IParallelRunner
 {
-    int DegreeOfParallelism { get; }
+    public int DegreeOfParallelism { get; }
 
-    public void Run(IParallelRunnable runnable) Enumerable.Range(0, DegreeOfParallelism).AsParallel().ForAll(i => runnable.Run(i, DegreeOfParallelism));
+    public void Run(IParallelRunnable runnable)
+    {
+        Enumerable.Range(0, DegreeOfParallelism).AsParallel().ForAll(i => runnable.Run(i, DegreeOfParallelism));
+    }
 }
 ```
 
-<a name='Overview_Threading_DefaultParallelRunner'></a>
 ### DefaultParallelRunner
-This is the default implementation of IParallelRunner. it uses exclusive Task to run an IParallelRunnable and only return when the full runnable has been processed. When `index == maxIndex` this is the calling thread.  
-It is safe to reuse the same DefaultParallelRunner in multiple system but it should not be used in parallel itself.
+This is the default implementation of `IParallelRunner`. It uses tasks to run an `IParallelRunnable` and only returns when the entire runnable has been processed. When `index == maxIndex` it indicates the code is in the calling thread.  
+It is safe to reuse the same `DefaultParallelRunner` in multiple systems but it should not be used in parallel itself.
 ```csharp
 IParallelRunner runner = new DefaultParallelRunner(Environment.ProcessorCount);
 
@@ -649,59 +625,55 @@ ISystem<float> system = new SequentialSystem<float>(
     new ParallelSystem2(runner));
 ```
 
-<a name='Overview_Command'></a>
 ## Command
-Since it is not possible to make structural modification on an Entity in a multithreading  context, the EntityCommandRecorder type is provided to adress this short-coming.  
-It is possible de record command on entities in a thread-safe way to later execute them when those structural modifications are safe to do.
+Since it is not possible to make structural modification on an entity in multi-threaded context, the `EntityCommandRecorder` type is provided to address this.  
+It is possible to record commands on entities in a thread-safe way to later execute them when those structural modifications are safe to do:
 ```csharp
-// This creates an expandable recorder with a default capacity of 1Ko
+// This creates an expandable recorder with a default capacity of 1024 commands
 EntityCommandRecorder recorder = new EntityCommandRecorder();
 
-// This creates a fixed capacity recorder of .5Ko
+// This creates a fixed capacity recorder of 512 commands
 EntityCommandRecorder recorder = new EntityCommandRecorder(512);
 
-// This creates an expandable recorder with a default capacity of .5Ko which can have a maximum capacity of 2Ko
+// This creates an expandable recorder with a default capacity of 512 command which can expand to a maximum capacity of 2048
 EntityCommandRecorder recorder = new EntityCommandRecorder(512, 2048);
 ```
 
-Note that a fixed capacity EntityCommandRecorder (or one which has expanded to its max capacity) has better performance.  
-When needed, an expandable EntityCommandRecorder will double its capacity so it is preferred to use a power of 2 as default capacity.
+Note that a fixed capacity `EntityCommandRecorder` (or one which has expanded to its max capacity) has the best performance.  
+When needed, an expandable `EntityCommandRecorder` will double its capacity so it is preferred to use a power of 2 as the default capacity.
 
+Some examples:
 ```csharp
 // Get a WorldRecord to record entity creation
 WorldRecord worldRecord = recorder.Record(world);
 
-// Create a new Entity defered and give an EntityRecord to record commands on it
-EntityRecord newRecord = worldRecord.CreateEntity();
+// Defers the creation of a new entity
+EntityRecord entityRecord = worldRecord.CreateEntity();
 
-// Register an Entity and give an EntityRecord to record commands on it
-EntityRecord record = recorder.Record(entity);
-
-// EntityRecord has the same API as Entity so all action expected are available to record as command this way
-newRecord.Set<bool>(true);
+// EntityRecord has the same API as Entity so all actions expected are available to record as commands
+entityRecord.Set<bool>(true);
 
 // To execute all recorded commands
 recorder.Execute();
 ```
 
-<a name='Overview_Serialization'></a>
 ## Serialization
-DefaultEcs support serialization to save and load a World state. Two implementations are provided which are equals in feature and it is possible to create a custom serialization engine using the framework of your choice by implementing a set of interfaces.
+DefaultEcs supports serialization to save and load a world state. Two implementations are provided which are equal in functionality and it is possible to create a custom serialization engine using the framework of your choice by implementing a set of interfaces:
 
-- ISerializer is the base interface
-- IComponentTypeReader is used to get the settings of the serialized World in case a component max capacity has been set for a specific type different from the world max capacity
-- IComponentReader is used to get all the components of an Entity
+- `ISerializer` is the base interface
+- `IComponentTypeReader` is used to get the settings of the serialized world in case a component max capacity has been set for a specific type different from the world's max capacity
+- `IComponentReader` is used to get all the components of an entity
 
-The provided implementation TextSerializer and BinarySerializer are highly permissive and will serialize every fields and properties even if the are private or readonly and do not require any attribute decoration to work.  
-This was a target from the get go as graphic and framework libraries do not always have well decorated type which would be used as component.  
-Although the lowest target is netstandard1.1, please be aware that the capability of both implementation to handle type with no default constructor maybe not work if the version of your .NET plateform is too low. Other known limitations are:
-- do not handle multidimensional arrays
-- do not handle cyclic object graph (all objects are copied, thus creating an infinit loop)
-- not compatible with Xamarin.iOS, AOT platforms (use System.Reflection.Emit namespace)
+The provided implementations for `TextSerializer` and `BinarySerializer` are highly permissive and will serialize all fields and properties even if they are private or read-only, and do not require any attributes to work.  
+This was the goal from the start as graphic and framework libraries do not always have well decorated types which would be used as components.  
+Although the lowest target is netstandard1.1, please be aware that the capability of both implementations to handle types with no default constructors may not work if the version of your .NET platform is too low. Other known limitations are:
+- no multi-dimensional array support
+- no cyclic object graph support (all objects are copied, thus creating an infinite loop)
+- not compatible with Xamarin.iOS, AOT platforms (uses the `System.Reflection.Emit` namespace)
 
 
 ```csharp
-ISerializer serializer = new TextSerializer();
+ISerializer serializer = new TextSerializer(); // or BinarySerializer
 
 using (Stream stream = File.Create(filePath))
 {
@@ -713,7 +685,8 @@ using (Stream stream = File.OpenRead(filePath))
     World worldCopy = serializer.Deserialize(stream);
 }
 ```
-Each implementation has its own serialization context which can be used to transform a given type to something else or just change the value at serialization and deserialization time.
+
+Each implementation has its own serialization context which can be used to transform a given type to something else or just change the value during serialization or deserialization.
 ```csharp
 using BinarySerializationContext context = new BinarySerializationContext()
     .Marshal<string, string>(_ => null) // set every string as null during serialization
@@ -723,23 +696,22 @@ using BinarySerializationContext context = new BinarySerializationContext()
 BinarySerializer serializer = new BinarySerializer(context);
 ```
 
-<a name='Overview_Serialization_TextSerializer'></a>
 ### TextSerializer
 The purpose of this serializer is to provide a readable save format which can be edited by hand.
 ```
-// declare the maximum number of entity in the World, this must be before any Entity or ComponentMaxCapacity line
+// declare the maximum number of entities in the World, this must be before any Entity or ComponentMaxCapacity line
 WorldMaxCapacity 42
 
-// this line is used to define an alias for a type used as component inside the world and must be declared before being used
+// this line is used to define an alias for a type used as a component inside the world and must be declared before being used
 ComponentType Int32 System.Int32, System.Private.CoreLib
 
 // this line is used to set the max capacity for the given type, in case it is different from the world max capacity
 ComponentMaxCapacity Int32 13
 
-// this create a new entity with the id "Foo"
+// this creates a new entity with the id "Foo"
 Entity Foo
 
-// this line set the component of the type with the alias Int32 on the previously created Entity to the value 13
+// this line sets the component of the type with the alias Int32 on the previously created Entity to the value 13
 Component Int32 13
 
 // let's say we have the type defined as such already declared with the alias Test
@@ -750,68 +722,63 @@ Component Int32 13
 // }
 ComponentType Test MyNamespace.Text, MyLib
 
-// composite objects are setted like this
+// composite objects are set like this
 Component Test {
-	Hello 666
+	Hello 42
 	// this line is ignored since the type does not have a member with the name Wow
 	// also the World member will have its default value since not present
-	Wow 42
+	Wow 43
 }
 
-// this create a new entity with no id
+// this creates a new entity with no id
 Entity
 
 // this sets the component of the type with the alias Test of the previously created Entity as the same as the one of the Entity with the id Foo
 ComponentSameAs Test Foo
 ```
-<a name='Overview_Serialization_BinarySerializer'></a>
 ### BinarySerializer
-This serializer is optimized for speed and file space.
+This serializer is optimized for speed and file size.
 
-<a name='Extension'></a>
 # Extension
 A DefaultEcs.Extension project is present to show how other features can be built upon the base framework. Those features are just provided as example and are not part of DefaultEcs because the implementation is not generic nor satisfactory enough.
-- [Children](https://github.com/Doraku/DefaultEcs/blob/master/source/DefaultEcs.Extension/Children/EntityExtension.cs) makes so entities can be linked together so disposing the parent will also dispose its children
-- [Hierarchy](https://github.com/Doraku/DefaultEcs/tree/master/source/DefaultEcs.Extension/Hierarchy) show an example on how to create hierarchy level between entities so parents are processed before their children
+- [Children](https://github.com/Doraku/DefaultEcs/blob/master/source/DefaultEcs.Extension/Children/EntityExtension.cs) makes it so entities can be linked together and disposing the parent will also dispose its children
+- [Hierarchy](https://github.com/Doraku/DefaultEcs/tree/master/source/DefaultEcs.Extension/Hierarchy) shows an example on how to create a hierarchy level between entities so parents are processed before their children
 
-<a name='Sample'></a>
 # Sample
-Some sample projects are available to give a better picture on how to use DefaultEcs. Those exemples were done relatively fast so they are probably not the best representation of the Entity Component System framework application.
+Some sample projects are available to paint a better picture on how to use DefaultEcs. Those examples were done relatively fast so they might not be an adequate representation of what an Entity Component System framework application might look like.
 
 [DefaultBoids](https://github.com/Doraku/DefaultEcs/tree/master/source/Sample/DefaultBoids)
 
 [![DefaultBoids](https://img.youtube.com/vi/yEdcqOTCteY/0.jpg)](https://youtu.be/yEdcqOTCteY)
 
 A really simple implementation of a [boids simulation](https://en.wikipedia.org/wiki/Boids), here displaying 30k boids with an old Intel Core i5-3570K CPU 3.40GHz at ~70fps.  
-This project use code generation from [DefaultEcs.Analyzer](https://github.com/Doraku/DefaultEcs.Analyzer) for its systems whenever possible.
+This project uses code generation from [DefaultEcs.Analyzer](https://github.com/Doraku/DefaultEcs.Analyzer) for its systems where possible.
 
 [DefaultBrick](https://github.com/Doraku/DefaultEcs/tree/master/source/Sample/DefaultBrick)
 [win10-x64](https://github.com/Doraku/DefaultEcs/releases/download/v0.9.0/DefaultBrick_win10-x64.zip)
 
 ![](https://github.com/Doraku/DefaultEcs/raw/master/image/defaultbrick.gif)
 
-Basic breakout clone. The collision is buggy! As said not much time was spent debuging those. Ball moves faster as the more bricks you destroy and reset to default speed if lost. The stage reload once completed.  
-This project do not use attribute for system query, everything is statically declared.
+Basic breakout clone. The collision is buggy! As said before, not much time was spent debugging those. Ball moves faster the more bricks you destroy and resets to default speed if you lose. The stage reloads once completed.  
+This project does not use attributes for system queries, everything is statically declared.
 
 [DefaultSlap](https://github.com/Doraku/DefaultEcs/tree/master/source/Sample/DefaultSlap)
 [win10-x64](https://github.com/Doraku/DefaultEcs/releases/download/v0.9.0/DefaultSlap_win10-x64.zip)
 
 ![](https://github.com/Doraku/DefaultEcs/raw/master/image/defaultslap.gif)
 
-Basic fly swatter clone. Every five seconds, flies (blue square) will damage the player (up to 3 times until the "game" resets) and new ones will spawn.  
-This project use attributes for system query.
+Basic fly swatter clone. Every five seconds flies (blue squares) will damage the player (up to 3 times until the "game" resets) and new ones will spawn.  
+This project uses attributes for system queries.
 
-<a name='Projects'></a>
 # Projects using DefaultEcs
-Your game uses DefaultEcs? Don't hesitate to contact me.  
+Does your game use DefaultEcs? Don't hesitate to contact me.  
 
 [![Chambers of Anubis](https://img.itch.zone/aW1nLzQ2MDYzODcucG5n/original/IALw4S.png)](https://github.com/PodeCaradox/HellowIInJam)
 
-<a name='Dependencies'></a>
 # Dependencies
-CI, tests and code quality rely on those awesome projects:
+CI, tests and code quality rely on these awesome projects:
 - [Coverlet](https://github.com/coverlet-coverage/coverlet)
-- [NFulent](https://github.com/tpierrain/NFluent)
+- [NFluent](https://github.com/tpierrain/NFluent)
 - [NSubstitute](https://github.com/nsubstitute/NSubstitute)
 - [Roslynator](https://github.com/JosefPihrt/Roslynator)
 - [XUnit](https://github.com/xunit/xunit)


### PR DESCRIPTION
Hopefully that's everything (and not too much)!

Here's what I've done:
- updated the table of contents to refer to headers instead of the dummy `<a>` elements
- fixed all typos I could find, both outside and inside code blocks
- wrapped all type names in inline code, e.g. `SomeClass`
- reworded some sentences that were incorrect or confusing
- fixed code that wouldn't compile
- redone the non thread-safe operation list ([this one](https://github.com/Quahu/DefaultEcs/tree/readme-fix#threading)) by essentially grouping the actions in a way which I think is slightly easier to digest